### PR TITLE
Fix UI not refreshing in realtime

### DIFF
--- a/BarDisplay.lua
+++ b/BarDisplay.lua
@@ -243,11 +243,6 @@ end
 
 -- Called by Skada windows when the display should be updated to match the dataset.
 function mod:Update(win)
-	-- Lazy sorting: track if we need to sort
-	local prevBarCount = win.bargroup.barCount or 0
-	local prevMaxValue = win.metadata.prevMaxValue
-	local needsSort = false
-
 	-- Some modes may alter title continously.
 	local fs = win.bargroup.button:GetFontString()
 	if fs then
@@ -507,25 +502,17 @@ function mod:Update(win)
 		end
 	end
 
-	-- Determine if sorting is needed
-	local currentBarCount = win.bargroup.barCount or 0
-	local maxValueChanged = (win.metadata.maxvalue ~= prevMaxValue)
-	
-	-- Sort if: bar count changed, maxvalue changed, or using ordersort
-	if currentBarCount ~= prevBarCount or maxValueChanged or win.metadata.ordersort then
-		-- Sort by the order in the data table if we are using "ordersort".
-		if win.metadata.ordersort then
-			win.bargroup:SetSortFunction(bar_order_sort)
-			win.bargroup:SortBars()
-		else
-			win.bargroup:SetSortFunction(nil)
-			win.bargroup:SortBars()
-		end
-		
-		-- Store values for next update
-		win.metadata.prevMaxValue = win.metadata.maxvalue
+	-- Always sort after applying the dataset. The previous "lazy" guard
+	-- compared win.bargroup.barCount before and after the loop, but barCount
+	-- is only assigned inside SortBars() itself, so it never differed and the
+	-- guard suppressed legitimate re-sorts (rank changes, new/removed bars,
+	-- ordersort updates). Sorting a few dozen bars per tick is cheap.
+	if win.metadata.ordersort then
+		win.bargroup:SetSortFunction(bar_order_sort)
+	else
+		win.bargroup:SetSortFunction(nil)
 	end
-
+	win.bargroup:SortBars()
 
 end
 

--- a/NativeAPI.lua
+++ b/NativeAPI.lua
@@ -20,13 +20,28 @@ local NativeAPI = {}
 Skada.NativeAPI = NativeAPI
 
 -- Cache and state for performance optimization
--- Using TTL-based caching instead of per-frame wipes
+-- TTL must be <= the Skada Tick interval (default 0.25s) so the UI never
+-- shows stale snapshots between ticks. We also explicitly invalidate on
+-- DAMAGE_METER_*_UPDATED events from Skada.lua, which is the authoritative
+-- signal that Blizzard's snapshot has changed.
 NativeAPI.cache = {
 	results = {},
 	available = true, -- Is C_DamageMeter currently responsive?
-	ttl = 0.5,        -- Cache TTL in seconds (500ms)
+	ttl = 0.1,        -- Cache TTL in seconds (100ms) - smaller than Tick interval
 	lastCheck = 0     -- Last time we checked availability
 }
+
+--[[
+	Invalidate all cached session/source views.
+	Called from DAMAGE_METER_COMBAT_SESSION_UPDATED and
+	DAMAGE_METER_CURRENT_SESSION_UPDATED so the next read returns fresh data
+	instead of the previous tick's snapshot.
+]]
+function NativeAPI:InvalidateCache()
+	if self.cache and self.cache.results then
+		wipe(self.cache.results)
+	end
+end
 
 -- Persistent cache for discovered session types
 NativeAPI.sessionTypeCache = {

--- a/Options.lua
+++ b/Options.lua
@@ -434,7 +434,10 @@ Skada.options = {
 					max = 1,
 					step = 0.05,
 					get = function() return Skada.db.profile.updatefrequency end,
-					set = function(self, opt) Skada.db.profile.updatefrequency = opt end,
+					set = function(self, opt)
+						Skada.db.profile.updatefrequency = opt
+						Skada:ApplyUpdateFrequency()
+					end,
 					order = 18,
 					width = "double",
 				},

--- a/Skada.lua
+++ b/Skada.lua
@@ -2406,7 +2406,7 @@ function Skada:OnEnable()
 	self.NativeAPI:TestSessionTypes()
 
 	-- Single repeating timer handles combat transitions, simulation, and display updates
-	self:ScheduleRepeatingTimer("Tick", self.db.profile.updatefrequency or 0.25)
+	self.tickTimer = self:ScheduleRepeatingTimer("Tick", self.db.profile.updatefrequency or 0.25)
 
 	-- Group and zone change events for data reset triggers
 	self:RegisterEvent("GROUP_ROSTER_UPDATE")
@@ -2423,6 +2423,16 @@ end
 function Skada:OnMediaRegistered(event, mediaType, key)
 	-- Re-apply settings when new media is registered to ensure fonts/textures are updated
 	self:ApplySettings()
+end
+
+-- Reschedule the Tick timer when the user changes updatefrequency in Options.
+-- Without this the new value only took effect after /reload.
+function Skada:ApplyUpdateFrequency()
+	if self.tickTimer then
+		self:CancelTimer(self.tickTimer)
+		self.tickTimer = nil
+	end
+	self.tickTimer = self:ScheduleRepeatingTimer("Tick", self.db.profile.updatefrequency or 0.25)
 end
 
 function Skada:AddLoadableModule(name, description, func)

--- a/Skada.lua
+++ b/Skada.lua
@@ -1274,13 +1274,16 @@ function Skada:find_player(set, playerGUID)
 	return self:find_player_in_session(set, playerGUID)
 end
 
--- Native API Event Handlers — just flag that data changed.
+-- Native API Event Handlers — invalidate any cached session snapshots so the
+-- next Tick() reads fresh data, then flag that data changed.
 -- The Tick() timer handles combat transitions and display updates.
 function Skada:DAMAGE_METER_COMBAT_SESSION_UPDATED()
+	if self.NativeAPI then self.NativeAPI:InvalidateCache() end
 	changed = true
 end
 
 function Skada:DAMAGE_METER_CURRENT_SESSION_UPDATED()
+	if self.NativeAPI then self.NativeAPI:InvalidateCache() end
 	changed = true
 end
 


### PR DESCRIPTION
## Summary

The Skada window appeared frozen mid-combat: bar values, totals, the DPS feed and rankings would only "tick" intermittently or not at all, even with `Update frequency` set to its minimum. Tracing the data path from `Skada:Tick()` → `UpdateDisplay()` → `NativeAPI:GetSessionView()` → `BarDisplay:Update()` surfaced two real bugs (plus one drive-by) that compound to produce the visible stall.

## Root causes

### 1. NativeAPI session/source cache outlives the Tick interval

`NativeAPI.lua` cached the results of `C_DamageMeter.GetCombatSessionFromType` / `GetCombatSessionSourceFromType` with `ttl = 0.5` (500 ms). `Skada:Tick()` fires every `updatefrequency` (default **0.25 s**), so every other tick the cache was still warm and handed back the previous snapshot. Result: the UI looked like it refreshed at ~2 Hz at best, regardless of the user's setting. The `DAMAGE_METER_*_UPDATED` events only set the `changed` flag — they never invalidated the cache.

### 2. `BarDisplay:Update` "lazy sort" guard was structurally dead

```lua
local prevBarCount = win.bargroup.barCount or 0
...
local currentBarCount = win.bargroup.barCount or 0
if currentBarCount ~= prevBarCount or maxValueChanged or win.metadata.ordersort then
    ... SortBars() ...
end
```

`win.bargroup.barCount` is only ever assigned inside `barListPrototype:SortBars()` itself (`lib/SpecializedLibBars-1.0/SpecializedLibBars-1.0.lua`, line 1066). Neither `NewBarFromPrototype` (creates bars) nor `ReleaseBar` (removes them) touches it, and nothing in `Update` between the two reads modifies it. So `prevBarCount == currentBarCount` is **always true** and the guard collapses to `maxValueChanged or ordersort`.

Consequences:

- Rankings below the top bar changed but bars didn't reposition (top value unchanged → no resort).
- Newly created bars (`mod:CreateBar` → `NewCounterBar`) stayed unpositioned until the top value happened to move.
- Stale bars removed via `RemoveBar` (e.g. on `combat_N` ↔ GUID id transitions) lingered visually until the next sort.

### 3. (drive-by) `Update frequency` option required `/reload` to take effect

`ScheduleRepeatingTimer("Tick", …)` was called once in `OnEnable` with the current value; the Options slider only wrote to the saved variable, never to the live timer.

## Changes

| Commit | Files | Description |
| --- | --- | --- |
| `Fix stale UI: invalidate NativeAPI session cache on updates` | `NativeAPI.lua`, `Skada.lua` | Shorten cache TTL `0.5s → 0.1s`. Add `NativeAPI:InvalidateCache()` and call it from `DAMAGE_METER_COMBAT_SESSION_UPDATED` / `DAMAGE_METER_CURRENT_SESSION_UPDATED`. |
| `Fix stale UI: always re-sort bars after dataset update` | `BarDisplay.lua` | Remove the broken `barCount` guard. Sort every `Update` (cheap for the tens of bars we have). |
| `Apply 'Update frequency' option without /reload` | `Skada.lua`, `Options.lua` | Store the Tick timer handle as `self.tickTimer`, add `Skada:ApplyUpdateFrequency()` to cancel + reschedule, wire it from the Options setter. |

## Test plan

- Out of combat in Simulation Mode: bars animate every tick; changing `Update frequency` slider takes effect immediately without `/reload`.
- In real combat: bar values, the total bar, DPS feed and rankings update at the configured rate; new players added to bars appear within one tick; bars for departing players disappear within one tick.
- Boss encounters: combat-end transition still restores views (`returnaftercombat`) and shows historical totals.
- PvP / solo with `hidesolo` / `hidepvp` still hide/show correctly (unchanged paths).

## Risk

Low. The cache TTL shrink and unconditional sort match the addon's pre-optimization behaviour; both "optimizations" were ineffective in their current form. The timer reschedule only fires on user action.

## Compatibility

WoW 12.0 (Midnight) only. No changes to module API or saved variables.